### PR TITLE
feature-rootOverlay-zoomWidget

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,14 @@ Now you can use `PinchToZoomScrollableWidget` as a widget in your code.
 
 | props         |   types    |                                 description                                  |
 |:--------------|:----------:|:----------------------------------------------------------------------------:|
-| child         |  `Widget`  |                              Widget for zooming.                              |
+| child         |  `Widget`  |           Child Widget and used for zooming if zoomChild is null.            |
+| zoomChild     |  `Widget`  |                             Widget for zooming.                              |
 | resetDuration | `Duration` | The duration of the reset animation. Default is Duration(milliseconds: 200). |
 | resetCurve    |  `Curve`   |          The curve of the reset animation. Default is Curves.ease.           |
 | clipBehavior  |   `Clip`   |        Clipping behavior for InteractiveViewer. Default is Clip.none.        |
 | maxScale      |  `double`  |                   The maximum allowed scale. Default to 8.                   |
 | overlayColor  |  `Color`   |           Overlay background color. Default is Color(0x42000000).            |
 | saveState     |   `bool`   |        Use [GlobalKey] for saving state of [child]. Default is False.        |
+| rootOverlay   |   `bool`   |         Overlay.of(context) will use rootOverlay. Default is False.          |
 
 Feel free to fork this repository and send pull request 🏁👍


### PR DESCRIPTION
**Two new features :** 
- rootOverlay to allow developer to use it to force the overlay to be on the first plan in case of nested navigator.
- zoomChild to change the pinched zoom widget.

**RootOverlay :** 
Overlay.of(context) can use rootOverlay to force the new overlay to be on top of others. It can also be used in case of nested navigation to display the overlay in the first plan (like rootNavigator).

**ZoomChild :**

ZoomChild can be used to replace the widget during the pinch to zoom action. A Use case can be to increase the image quality to allow user to see a high quality one during zoom and once released, use a normal quality. An other use case can just be to offer more customization.

PS : Nice job, this new interactive viewer is far better.
No possibility to make things through an extends class or I didn't know something else to create a pull request to the flutter team to improve the class InteractiveViewer ?

